### PR TITLE
Fix NaN breaking graph when times are equal

### DIFF
--- a/UI/Components/GraphComponent.cs
+++ b/UI/Components/GraphComponent.cs
@@ -204,7 +204,11 @@ namespace LiveSplit.UI.Components
             }
             else
             {
-                var ratio = (heightOne - Middle) / (heightOne - heightTwo);
+                float ratio = (heightOne - Middle) / (heightOne - heightTwo);
+                if (float.IsNaN(ratio))
+                {
+                    ratio = 0.0f;
+                }
                 AddFillFirstHalf(g, TotalDelta, Middle, brush, heightOne, widthOne, widthTwo, y, pointArray, ratio);
                 AddFillSecondHalf(g, TotalDelta, Middle, brush, heightTwo, widthOne, widthTwo, y, pointArray, ratio);
             }


### PR DESCRIPTION
Happens commonly with Quake autosplitter cause start map doesn't get timed in IGT.